### PR TITLE
Release preparation: Update java compilance version for all the packages

### DIFF
--- a/plugin/de.fraunhofer.ipa.deployment.feature/feature.xml
+++ b/plugin/de.fraunhofer.ipa.deployment.feature/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="de.fraunhofer.ipa.deployment.feature"
-      label="Feature"
+      label="RosTooling deployment feature"
       version="1.0.0.qualifier">
 
    <description url="http://www.example.com/description">
@@ -15,5 +15,110 @@
    <license url="http://www.example.com/license">
       [Enter License Description here.]
    </license>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.plan.xtext"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.plan.xtext.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.plan.xtext.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.planros.xtext"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.planros.xtext.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.planros.xtext.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.util"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.util.xtext"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.util.xtext.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deployment.util.xtext.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.deploymentPlan"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.targetEnvironment"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.targetEnvironment.xtext"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.targetEnvironment.xtext.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.fraunhofer.ipa.targetEnvironment.xtext.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ide/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ide/.classpath
@@ -3,7 +3,7 @@
     <classpathentry kind="src" path="src"/>
     <classpathentry kind="src" path="src-gen"/>
     <classpathentry kind="src" path="xtend-gen"/>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ide/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ide/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.plan.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.plan.xtext.ide
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.plan.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -12,7 +12,7 @@ Require-Bundle: de.fraunhofer.ipa.deployment.plan.xtext,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.ide.contentassist.antlr.lexer,
  de.fraunhofer.ipa.deployment.ide.contentassist.antlr,
  de.fraunhofer.ipa.deployment.ide.contentassist.antlr.internal

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.tests/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.tests/.classpath
@@ -15,7 +15,7 @@
             <attribute name="test" value="true"/>
         </attributes>
     </classpathentry>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.tests/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.plan.xtext.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.plan.xtext.tests
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.plan.xtext.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -14,5 +14,5 @@ Require-Bundle: de.fraunhofer.ipa.deployment.plan.xtext,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.1.0,6.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.tests;x-internal=true

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui.tests/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui.tests/.classpath
@@ -15,7 +15,7 @@
             <attribute name="test" value="true"/>
         </attributes>
     </classpathentry>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui.tests/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.plan.xtext.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.plan.xtext.ui.tests
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.plan.xtext.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -17,5 +17,5 @@ Require-Bundle: de.fraunhofer.ipa.deployment.plan.xtext.ui,
  org.eclipse.ui.workbench;resolution:=optional
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.1.0,6.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.ui.tests;x-internal=true

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui/.classpath
@@ -3,7 +3,7 @@
     <classpathentry kind="src" path="src"/>
     <classpathentry kind="src" path="src-gen"/>
     <classpathentry kind="src" path="xtend-gen"/>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.plan.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.plan.xtext.ui
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.plan.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -20,7 +20,7 @@ Require-Bundle: de.fraunhofer.ipa.deployment.plan.xtext,
  org.eclipse.xtext.builder,
  de.fraunhofer.ipa.deployment.util.xtext.ui
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.ui.quickfix,
  de.fraunhofer.ipa.deployment.plan.xtext.ui.internal,
  de.fraunhofer.ipa.deployment.ui.contentassist

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19">
     <attributes>
       <attribute name="module" value="true"/>
     </attributes>

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.plan.xtext/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.plan.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.plan.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.plan.xtext
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.plan.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -16,7 +16,7 @@ Require-Bundle: de.fraunhofer.ipa.targetEnvironment,
  org.eclipse.xtext.util,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  com.google.gson;bundle-version="2.9.1"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.generator,
  de.fraunhofer.ipa.deployment.parser.antlr.lexer,
  de.fraunhofer.ipa.deployment.services,

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ide/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ide/.classpath
@@ -3,7 +3,7 @@
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="src" path="src-gen"/>
   <classpathentry kind="src" path="xtend-gen"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ide/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ide/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.planros.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.planros.xtext.ide
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.planros.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -11,7 +11,7 @@ Require-Bundle: de.fraunhofer.ipa.deployment.planros.xtext,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.ide.contentassist.antlr.lexer,
  de.fraunhofer.ipa.deployment.ide.contentassist.antlr,
  de.fraunhofer.ipa.deployment.ide.contentassist.antlr.internal

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.tests/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.tests/.classpath
@@ -15,7 +15,7 @@
       <attribute name="test" value="true"/>
     </attributes>
   </classpathentry>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.tests/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.planros.xtext.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.planros.xtext.tests
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.planros.xtext.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -13,5 +13,5 @@ Require-Bundle: de.fraunhofer.ipa.deployment.planros.xtext,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.1.0,6.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.tests;x-internal=true

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui.tests/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui.tests/.classpath
@@ -15,7 +15,7 @@
       <attribute name="test" value="true"/>
     </attributes>
   </classpathentry>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui.tests/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.planros.xtext.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.planros.xtext.ui.tests
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.planros.xtext.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -16,5 +16,5 @@ Require-Bundle: de.fraunhofer.ipa.deployment.planros.xtext.ui,
  org.eclipse.ui.workbench;resolution:=optional
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.1.0,6.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.ui.tests;x-internal=true

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui/.classpath
@@ -3,7 +3,7 @@
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="src" path="src-gen"/>
   <classpathentry kind="src" path="xtend-gen"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.planros.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.planros.xtext.ui
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.planros.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -19,7 +19,7 @@ Require-Bundle: de.fraunhofer.ipa.deployment.planros.xtext,
  org.eclipse.xtext.builder,
  de.fraunhofer.ipa.deployment.plan.xtext.ui;bundle-version="1.0.0"
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.ui.quickfix,
  de.fraunhofer.ipa.deployment.planros.xtext.ui.internal,
  de.fraunhofer.ipa.deployment.ui.contentassist

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext/.classpath
@@ -3,7 +3,7 @@
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="src" path="src-gen"/>
   <classpathentry kind="src" path="xtend-gen"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.planros.xtext/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.planros.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.planros.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.planros.xtext
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.planros.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -16,7 +16,7 @@ Require-Bundle: de.fraunhofer.ipa.deploymentPlan,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  de.fraunhofer.ipa.rossystem,
  de.fraunhofer.ipa.ros.xtext;bundle-version="2.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment,
  de.fraunhofer.ipa.deployment.formatting2,
  de.fraunhofer.ipa.deployment.generator,

--- a/plugin/de.fraunhofer.ipa.deployment.standalone/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.standalone/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -12,4 +12,4 @@ org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.standalone/pom.xml
+++ b/plugin/de.fraunhofer.ipa.deployment.standalone/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>de.fraunhofer.ipa.ros</groupId>
             <artifactId>de.fraunhofer.ipa.rossystem</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.ide/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.ide/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="src" path="src/"/>
     <classpathentry kind="src" path="src-gen/"/>

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.ide/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.ide/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.util.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.util.xtext.ide
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.util.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -11,7 +11,7 @@ Require-Bundle: de.fraunhofer.ipa.deployment.util.xtext,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.ide.contentassist.antlr.lexer,
  de.fraunhofer.ipa.deployment.ide.contentassist.antlr,
  de.fraunhofer.ipa.deployment.ide.contentassist.antlr.internal

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.tests/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="src" path="src/">
         <attributes>

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.tests/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.util.xtext.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.util.xtext.tests
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.util.xtext.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -13,5 +13,5 @@ Require-Bundle: de.fraunhofer.ipa.deployment.util.xtext,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.1.0,6.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.tests;x-internal=true

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui.tests/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="src" path="src/">
         <attributes>

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui.tests/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.util.xtext.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.util.xtext.ui.tests
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.util.xtext.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -16,5 +16,5 @@ Require-Bundle: de.fraunhofer.ipa.deployment.util.xtext.ui,
  org.eclipse.ui.workbench;resolution:=optional
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.1.0,6.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.ui.tests;x-internal=true

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="src" path="src/"/>
     <classpathentry kind="src" path="src-gen/"/>

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.deployment.util.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.deployment.util.xtext.ui
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.deployment.util.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -18,7 +18,7 @@ Require-Bundle: de.fraunhofer.ipa.deployment.util.xtext,
  org.eclipse.compare,
  org.eclipse.xtext.builder
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment.ui.quickfix,
  de.fraunhofer.ipa.deployment.util.xtext.ui.internal,
  de.fraunhofer.ipa.deployment.ui.contentassist

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext/.classpath
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="src" path="src"/>
     <classpathentry kind="src" path="src-gen"/>

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.deployment.util.xtext/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.deployment.util.xtext/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: de.fraunhofer.ipa.deployment.util,
  org.eclipse.xtext.xbase.lib;bundle-version="2.30.0",
  org.eclipse.xtext.util,
  org.antlr.runtime;bundle-version="3.2.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.deployment;uses:="com.google.inject,org.eclipse.xtext.service,org.eclipse.xtext",
  de.fraunhofer.ipa.deployment.formatting2;uses:="org.eclipse.xtext.formatting2",
  de.fraunhofer.ipa.deployment.generator;uses:="org.eclipse.xtext.generator,org.eclipse.emf.ecore.resource",

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ide/.classpath
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ide/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="src" path="src/"/>
     <classpathentry kind="src" path="src-gen/"/>

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ide/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ide/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.targetEnvironment.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.targetEnvironment.xtext.ide
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.targetEnvironment.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -12,7 +12,7 @@ Require-Bundle: de.fraunhofer.ipa.targetEnvironment.xtext,
  org.eclipse.xtext.xbase.ide,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  de.fraunhofer.ipa.deployment.util.xtext
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.targetEnvironment.ide.contentassist.antlr,
  de.fraunhofer.ipa.targetEnvironment.ide.contentassist.antlr.internal,
  de.fraunhofer.ipa.targetEnvironment.ide.contentassist.antlr.lexer

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.tests/.classpath
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="src" path="src/">
         <attributes>

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.tests/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.targetEnvironment.xtext.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.targetEnvironment.xtext.tests
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.targetEnvironment.xtext.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -13,5 +13,5 @@ Require-Bundle: de.fraunhofer.ipa.targetEnvironment.xtext,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.1.0,6.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.targetEnvironment.tests;x-internal=true

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui.tests/.classpath
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="src" path="src/">
         <attributes>

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui.tests/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.targetEnvironment.xtext.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.targetEnvironment.xtext.ui.tests
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.targetEnvironment.xtext.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -16,5 +16,5 @@ Require-Bundle: de.fraunhofer.ipa.targetEnvironment.xtext.ui,
  org.eclipse.ui.workbench;resolution:=optional
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.1.0,6.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.targetEnvironment.ui.tests;x-internal=true

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui/.classpath
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui/.classpath
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19"/>
     <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
     <classpathentry kind="src" path="src/"/>
     <classpathentry kind="src" path="src-gen/"/>
-    <classpathentry kind="src" path="xtend-gen/"/>
     <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.targetEnvironment.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.targetEnvironment.xtext.ui
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.targetEnvironment.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -22,7 +22,7 @@ Require-Bundle: de.fraunhofer.ipa.targetEnvironment.xtext,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.targetEnvironment.ui.contentassist,
  de.fraunhofer.ipa.targetEnvironment.ui.quickfix,
  de.fraunhofer.ipa.targetEnvironment.xtext.ui.internal

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui/build.properties
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext.ui/build.properties
@@ -1,6 +1,5 @@
 source.. = src/,\
-           src-gen/,\
-           xtend-gen/
+           src-gen/
 bin.includes = .,\
                META-INF/,\
                plugin.xml

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext/.classpath
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19">
         <attributes>
             <attribute name="maven.pomderived" value="true"/>
         </attributes>

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=19

--- a/plugin/de.fraunhofer.ipa.targetEnvironment.xtext/META-INF/MANIFEST.MF
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: de.fraunhofer.ipa.targetEnvironment.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: de.fraunhofer.ipa.targetEnvironment.xtext
-Bundle-Vendor: My Company
+Bundle-Vendor: Fraunhofer IPA
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: de.fraunhofer.ipa.targetEnvironment.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -15,7 +15,7 @@ Require-Bundle: de.fraunhofer.ipa.targetEnvironment,
  org.antlr.runtime;bundle-version="4.7.2",
  de.fraunhofer.ipa.deployment.util.xtext;bundle-version="1.0.0",
  org.eclipse.xtend.lib;bundle-version="2.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-19
 Export-Package: de.fraunhofer.ipa.targetEnvironment,
  de.fraunhofer.ipa.targetEnvironment.serializer,
  de.fraunhofer.ipa.targetEnvironment.services,

--- a/plugin/de.fraunhofer.ipa.targetEnvironment/.classpath
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-19">
         <attributes>
             <attribute name="maven.pomderived" value="true"/>
         </attributes>

--- a/plugin/de.fraunhofer.ipa.targetEnvironment/.settings/org.eclipse.jdt.core.prefs
+++ b/plugin/de.fraunhofer.ipa.targetEnvironment/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=19
+org.eclipse.jdt.core.compiler.compliance=19
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=19


### PR DESCRIPTION
This PR updates the java compliance version to JavaSE-19, this is required to be able to create the feature as release. Apart from that, it adds the company's name to the plugins MANIFEST.

Thanks to these changes I could create the release, it is now available within the RosTooling in https://github.com/ipa320/RosTooling-update-site 

See:
![Peek 2024-02-27 14-11](https://github.com/ipa-rwu/deployment_plan_metamodel/assets/650568/62e12f25-f7c5-4b40-8720-5584ab7ce815)

Here the documentation: https://github.com/ipa320/RosTooling/blob/main/docu/Installation.md#option-1-using-the-release-version-recommended 

